### PR TITLE
Add URL encoding to search queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Yup ... it's _another_ Giphy client!! This project was mostly a skill-sharpening
 * [X] Add specs
   * [ ] Implement mocking for HTTP requests & JSON responses
 * [ ] Finish & publish documentation
-* [ ] Add URL encoding to search queries
+* [X] Add URL encoding to search queries
 * [ ] Implement optional query parameters where applicable
 * [ ] **Optional**: Implement CLI version?
 * [ ] **Optional**: Run some code quality tools once this gets close

--- a/lib/Giphit.rb
+++ b/lib/Giphit.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'httparty'
 require 'json'
+require 'uri'
 
 GIPHY_ENDPOINT = 'api.giphy.com'
 
@@ -35,7 +36,7 @@ class Giphit
   def search(q)
     response = get_response(
       api_path: '/v1/gifs/search',
-      query_object: { q: q }
+      query_object: { q: URI.escape(q) }
     )
     response.parsed_response["data"]
   end


### PR DESCRIPTION
For multiline search strings, they should be URL encoded.